### PR TITLE
Update testResultsProcessor name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then add to Jest config in the package.json
 ```
 ...
 "jest": {
-  "testResultsProcessor": "./node_modules/jest-json-repoter"
+  "testResultsProcessor": "jest-json-reporter"
 },
 ...
 ```


### PR DESCRIPTION
Thanks for the simple and useful module!

I noticed when installing that the package name modified line was misspelled. Also in my testing, it looks like you can omit the `./node_modules/` before the `testResultsProcessor` package name, and Jest assumes it's a node module (per the [documentation](https://facebook.github.io/jest/docs/configuration.html#testresultsprocessor-string)). 